### PR TITLE
Remove message when commits are compliant

### DIFF
--- a/src/main/resources/it/nicolasfarabegoli/gradle/commit-msg.sh
+++ b/src/main/resources/it/nicolasfarabegoli/gradle/commit-msg.sh
@@ -9,7 +9,6 @@ commit_message=$(cat "$1")
 
 # Check the message, if we match, all good baby.
 if [[ "$commit_message" =~ $conventional_commit_regex ]]; then
-   echo -e "\e[32mCommit message meets Conventional Commit standards...\e[0m"
    exit 0
 fi
 


### PR DESCRIPTION
This removes the success message when a commit follows the semantic commit spec, as a confirmation message is not strictly necessary (Git actually doing the commit is a good enough indicator that the commit message is compliant).