### PR TITLE
fix: end quote for commits regex

### DIFF
--- a/src/main/kotlin/it/nicolasfarabegoli/gradle/ConventionalCommitScript.kt
+++ b/src/main/kotlin/it/nicolasfarabegoli/gradle/ConventionalCommitScript.kt
@@ -39,7 +39,7 @@ private fun createCommitMessage(
         #!/usr/bin/env bash
         
         # Regex for conventional commits
-        conventional_commits_regex="^($typesRegex)(\\($scopesRegex))?!?: .+$
+        conventional_commits_regex="^($typesRegex)(\\($scopesRegex))?!?: .+$"
         
         # Get the commit message (the parameter we're given is just the path to the
         # temporary file which holds the message).


### PR DESCRIPTION
else:

```
.git/hooks/commit-msg: line 11: unexpected EOF while looking for matching `"'
.git/hooks/commit-msg: line 19: syntax error: unexpected end of file
```