### PR TITLE
fix(regex): fix scopes regex

### DIFF
--- a/src/main/kotlin/it/nicolasfarabegoli/gradle/ConventionalCommitScript.kt
+++ b/src/main/kotlin/it/nicolasfarabegoli/gradle/ConventionalCommitScript.kt
@@ -39,7 +39,7 @@ private fun createCommitMessage(
         #!/usr/bin/env bash
         
         # Regex for conventional commits
-        conventional_commits_regex="^($typesRegex)(\($scopesRegex\))?\!?:\ .+$"
+        conventional_commits_regex="^($typesRegex)(\(($scopesRegex)\))?\!?:\ .+$"
         
         # Get the commit message (the parameter we're given is just the path to the
         # temporary file which holds the message).


### PR DESCRIPTION
Scopes regex is now its own group. Previously, the only group was included the entire scope (including brackets), now there is another one including the scope names so it won't match the scope brackets. 

Links to tests:
https://regexr.com/6v1p7
https://regexr.com/6v1p4
