### PR TITLE
fix: change java version to 1.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
 
 tasks.withType<KotlinCompile> {
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "1.8"
         allWarningsAsErrors = true
     }
 }

--- a/src/main/kotlin/it/nicolasfarabegoli/gradle/ConventionalCommitScript.kt
+++ b/src/main/kotlin/it/nicolasfarabegoli/gradle/ConventionalCommitScript.kt
@@ -39,7 +39,7 @@ private fun createCommitMessage(
         #!/usr/bin/env bash
         
         # Regex for conventional commits
-        conventional_commits_regex="^($typesRegex)(\($scopesRegex\))?\!?:\ .+$"
+        conventional_commits_regex="^($typesRegex)(\(($scopesRegex)\))?\!?:\ .+$"
         
         # Get the commit message (the parameter we're given is just the path to the
         # temporary file which holds the message).


### PR DESCRIPTION
Hello, I'm attempting to use this in a Java 8 project and would like to be able to build the project using Java 8 but at the moment I have to use Java 11+.

I don't see a point in using Java 11 since Kotlin can target 1.8 and doing so would also allow the possible users of this plugin to be less limited. 