### PR TITLE
ci: run ci on java 8

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java-version: [11]
+        java-version: [8]
     name: Build and test
     runs-on: ${{ matrix.os }}
     steps:
@@ -53,7 +53,7 @@ jobs:
         uses: actions/setup-java@v3.5.1
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '8'
 
       - name: Install npm pakage
         run: npm install

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,5 +18,5 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 publish = { id = "com.gradle.plugin-publish", version = "1.0.0" }
-publish-central = { id = "it.nicolasfarabegoli.publish-to-maven-central", version = "1.1.3" }
+publish-central = { id = "it.nicolasfarabegoli.publish-to-maven-central", version = "1.1.4" }
 conventional-commits = { id = "it.nicolasfarabegoli.conventional-commits", version = "3.0.12" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,4 +19,4 @@ ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 publish = { id = "com.gradle.plugin-publish", version = "1.0.0" }
 publish-central = { id = "it.nicolasfarabegoli.publish-to-maven-central", version = "1.1.3" }
-conventional-commits = { id = "it.nicolasfarabegoli.conventional-commits", version = "3.0.10" }
+conventional-commits = { id = "it.nicolasfarabegoli.conventional-commits", version = "3.0.12" }


### PR DESCRIPTION
Just found out that the Gradle dependency manager doesn't respect the actual version of a plugin, but rather the `org.gradle.jvm.version` attribute. By default, this is set to the Gradle JVM version and since the new JVM 8 targeted plugin was still being built and published on Java 11 Gradle would still think it was on Java 11 when resolving dependencies.

The alternative is to simply set the `org.gradle.jvm.version` version attribute. I believe you can do this with the java plugin like so:
```kotlin
java {
    targetCompatibility = JavaVersion.VERSION_1_8
}
```
This would make the build not fail and it still be able to be published on using Java 11. 
Note: I'm not completely sure if `targetCompatibility = ...` sets the `org.gradle.jvm.version` so you might have to check that out yourself.

Anyway, I'm not sure if the ci commit type creates a new release with semantic-changelog so you may want to change that. 

Relates to: https://github.com/nicolasfara/conventional-commits/pull/103
More info: https://docs.gradle.org/current/userguide/variant_attributes.html