### PR TITLE
Allow for underscores in scopes

### DIFF
--- a/src/main/kotlin/it/nicolasfarabegoli/gradle/ConventionalCommitScript.kt
+++ b/src/main/kotlin/it/nicolasfarabegoli/gradle/ConventionalCommitScript.kt
@@ -36,7 +36,7 @@ private fun createCommitMessage(
     ignoreMessageCommit: String
 ): String {
     val typesRegex = types.joinToString("|")
-    val scopesRegex = if (scopes.isEmpty()) "[a-z \\-]+" else scopes.joinToString("|")
+    val scopesRegex = if (scopes.isEmpty()) "[a-z \\-_]+" else scopes.joinToString("|")
     val successMessageEcho = wrapInEcho(successMessage)
     val failureMessageEcho = wrapInEcho(failureMessage)
     return """


### PR DESCRIPTION
The conventional commit spec does not seem to disallow underscrores but the previous regex did not match them and so any scope with an underscore would fail the commit hook