### PR TITLE
docs: note that the 'scopes' key is a list of (bash) regexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ conventionalCommits {
 
 The following table describe all the available keys in the plugin
 
-| Key                  | Description                                                                                                | Default                                                                                      |
-|----------------------|------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-| `warningIfNoGitRoot` | A **warning** is raised if no `.git` root is found walking up until the `/` from the project folder.       | `true`                                                                                       |
-| `types`              | List of admitted types in the commit message.                                                              | `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test` |
-| `scopes`             | List of admitted scopes in the commit message. An empty list means that all scopes are admitted            | `emptyList`                                                                                  |
-| `successMessage`     | A message printed if the commit meets conventional commit. If `null` is set, no message is printed.        | "Commit message meets Conventional Commit standards..."                                      |
-| `failureMessage`     | A message printed if the commit **not** meets conventional commit. If `null` is set no message is printed. | "The commit message does not meet the Conventional Commit standard"                          |
+| Key                  | Description                                                                                                                   | Default                                                                                      |
+|----------------------|-------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| `warningIfNoGitRoot` | A **warning** is raised if no `.git` root is found walking up until the `/` from the project folder.                          | `true`                                                                                       |
+| `types`              | List of admitted types in the commit message.                                                                                 | `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test` |
+| `scopes`             | List of admitted scopes in the commit message in the form of (bash) regexes. An empty list is equal to `listOf("[a-z \-]+")`. | `listOf("[a-z \-]+")`                                                                        |
+| `successMessage`     | A message printed if the commit meets conventional commit. If `null` is set, no message is printed.                           | "Commit message meets Conventional Commit standards..."                                      |
+| `failureMessage`     | A message printed if the commit **not** meets conventional commit. If `null` is set no message is printed.                    | "The commit message does not meet the Conventional Commit standard"                          |


### PR DESCRIPTION
As noted in #442, some users may want to allow e.g. uppercase letters or numbers in their commit scope. This is not formally supported by the conventional commit standard but achievable by adding the relevant regex to the `scopes` configuration key. Unfortunately, it was not clear from the documentation that this key accepts (bash-style) regexes, making it hard for users to discover this functionality and risky to use in case of future changes to the implementation.

This commit explicitly notes that the `scopes` configuration key accepts bash-style regexes. It also changes the listed default for this key to be `listOf("[a-z \-]")`. While this last part may not be completely true (it should actually be `emptyList()`), this change does make the default clear to skimming readers.